### PR TITLE
Add the ability to pass build parameters through the trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jobs:
           poll-time: 10 # how often (seconds) to poll the jenkins server for results
           timeout-value: 600 # How long (seconds) to poll before timing out the action
           verbose: true # true/false - turns on extra logging
+          parameters: "PARAM1=VALUE PARAM2=VALUE" 
 ```
 
 ## Input Variables
@@ -48,3 +49,4 @@ Variable Name | Description
 **poll-time** | Time, in seconds, of how often the action should poll the Jenkins job to see if it has completed
 **timeout-value** | Time, in seconds, of how long the action should run before timing out, i.e. how long should the action wait for Jenkins to complete the job
 **verbose** | true/false. This value, when true, enables extra logging in the build output. By default it is false, meaning minimal logging
+**parameters** | A set of Jenkins build parameters to pass through on the job trigger. Example: "PARAM1=VALUE PARAM2=VALUE"

--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
       with:
         refresh-message-position: true
         message-id: jenkins-url
-        message: Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}
+        message: "Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}"
     - trigger-jenkins-job-using-api-2:
       run: |
         pollTime=${{ inputs.poll-time }}

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         verbose=${{ inputs.verbose }}
         userName=${{ inputs.jenkins-username }}
         password=${{ inputs.jenkins-pat }}
-        paramQueryString="${{ inputs.paramQueryString }}"
+        parameters="${{ inputs.parameters }}"
 
         BUILDCMD="build"
         PARAMARGS=""

--- a/action.yml
+++ b/action.yml
@@ -46,11 +46,16 @@ runs:
 
         BUILDCMD="build"
         PARAMARGS=""
-        if [[ -n $parameters ]]; then
-          BUILDCMD="buildWithParameters"
-          for $param in $parameters; do
-            echo "-F $param" >> $PARAMARGS
+        if [[ -n "$parameters" ]]; then
+          echo "PARAMS: $PARAMARGS"
+          for param in $parameters; do
+            if [[ -n "$PARAMARGS" ]]; then
+              PARAMARGS="${PARAMARGS}&"
+            fi
+            PARAMARGS="${PARAMARGS}${param}"
+            echo "PARAMS: $PARAMARGS"
           done
+          BUILDCMD="buildWithParameters?${PARAMARGS}"
         fi
 
         startTime=$(date)
@@ -63,7 +68,8 @@ runs:
 
         #Generate Crumb value
         CRUMB=`curl -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
-        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password" $PARAMARGS -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
+        echo "curl -I -s -X POST -u \"$userName:$password\" -H \"$CRUMB\" \"$urlOfJenkinsServer\"/job/\"$jenkinsJobName/$BUILDCMD\""
+        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password" "$PARAMARGS" -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
         
         if [[ $verbose == true ]]; then
           echo "Results of Triggering The Job:"

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,6 @@ inputs:
   parameters:
     description: 'build parameters in the format: KEY1=VALUE KEY2=VALUE'
     required: false
-outputs:
-  status: 
-    description: Jenkins Job Status
-    value: ${{ steps.trigger-jenkins-job-using-api.outputs.status }}
-  url: 
-    description: Jenkins Job URL
-    value: ${{ steps.trigger-jenkins-job-using-api.outputs.url }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -39,13 +39,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: trigger-jenkins-job-using-api
+    - id: trigger-jenkins-job-using-api-1
       run: |
         #Parameters
         urlOfJenkinsServer="${{ inputs.jenkins-server }}"
         jenkinsJobName="${{ inputs.jenkins-job }}"
-        pollTime=${{ inputs.poll-time }}
-        timeoutValue=${{ inputs.timeout-value }}
         verbose=${{ inputs.verbose }}
         userName=${{ inputs.jenkins-username }}
         password=${{ inputs.jenkins-pat }}
@@ -127,19 +125,38 @@ runs:
           echo "--------------------------------------"
         fi
 
+        echo "buildjson=${BUILDJSON}" >> $GITHUB_OUTPUT
+        echo "blocked=${BASH_REMATCH[1]}" >> GITHUB_OUTPUT
+        echo "buildnum=${BASH_REMATCH[2]}" >> GITHUB_OUTPUT
+        echo "buildurl=${BASE_REMATCH[3]}" >> GITHUB_OUTPUT
+      shell: bash
+    - uses: mshick/add-pr-comment@v2
+      with:
+        refresh-message-position: true
+        message-id: jenkins-url
+        message: Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}
+    - trigger-jenkins-job-using-api-2:
+      run: |
+        pollTime=${{ inputs.poll-time }}
+        timeoutValue=${{ inputs.timeout-value }}
+        verbose=${{ inputs.verbose }}
+        
+        BUILDJSON=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}
+        BLOCKED=${{ steps.trigger-jenkins-job-using-api-1.outputs.blocked }}
+        BUILDNUM=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildnum }}
+        BUILDURL=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}
+        
         #regex_blocked_status="\"blocked\"\s*:\s*([a-z]+)"
         regex="\"blocked\"\s*:\s*([a-z]+).*\"executable\".*?\"number\"\s*:\s*([0-9]+).*?\"url\"\s*:\s*\"(.*?)\""
         if [[ $BUILDJSON =~ $regex ]]; then
           if [[ $verbose == true ]]; then
-            echo "blocked: " ${BASH_REMATCH[1]} ;
-            echo "build number: " ${BASH_REMATCH[2]} ;
-            echo "build URL: " ${BASH_REMATCH[3]} ;
+            echo "blocked: " ${BLOCKED} ;
+            echo "build number: " ${BUILDNUM} ;
+            echo "build URL: " ${BUILDURL} ;
           fi
           echo "Job URL retrieved"
           echo "--------------------------------------"
-          BUILDURL=${BASH_REMATCH[3]};
-          echo "url=${BUILDURL}" >> $GITHUB_OUTPUT
-          if [[ "${BASH_REMATCH[1]}" == "true" ]]; then
+          if [[ "${BLOCKED}" == "true" ]]; then
             echo "Build Blocked. Exiting script with error"
             echo "--------------------------------------"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -135,7 +135,7 @@ runs:
         refresh-message-position: true
         message-id: jenkins-url
         message: "Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}"
-    - trigger-jenkins-job-using-api-2:
+    - id: trigger-jenkins-job-using-api-2
       run: |
         pollTime=${{ inputs.poll-time }}
         timeoutValue=${{ inputs.timeout-value }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: 'true/false - turns on verbose logging'
     required: false
     default: false
+  paramQueryString:
+    description: 'a query string specifying build parameters'
+    required: false
   
 runs:
   using: "composite"
@@ -39,6 +42,11 @@ runs:
         verbose=${{ inputs.verbose }}
         userName=${{ inputs.jenkins-username }}
         password=${{ inputs.jenkins-pat }}
+        paramQueryString=${{ inputs.paramQueryString }}
+
+        BUILDCMD="build"
+        if [[ -n $parameters ]]; then
+          BUILDCMD="buildWithParameters?${paramQueryString}"
 
         startTime=$(date)
         startTimeSeconds=$(date -d "$startTime" +%s) 
@@ -50,7 +58,7 @@ runs:
 
         #Generate Crumb value
         CRUMB=`curl -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
-        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password"  -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName"/build)
+        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password"  -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
         
         if [[ $verbose == true ]]; then
           echo "Results of Triggering The Job:"

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         verbose=${{ inputs.verbose }}
         userName=${{ inputs.jenkins-username }}
         password=${{ inputs.jenkins-pat }}
-        paramQueryString=${{ inputs.paramQueryString }}
+        paramQueryString="${{ inputs.paramQueryString }}"
 
         BUILDCMD="build"
         if [[ -n $parameters ]]; then

--- a/action.yml
+++ b/action.yml
@@ -67,9 +67,9 @@ runs:
         #This will return a 201 if the job is created, so we need to test for this
 
         #Generate Crumb value
-        CRUMB=`curl -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
+        CRUMB=`curl --retry=3 --retry-all-errors --retry-connrefused --retry-delay=10 -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
         echo "curl -I -s -X POST -u \"$userName:$password\" -H \"$CRUMB\" \"$urlOfJenkinsServer\"/job/\"$jenkinsJobName/$BUILDCMD\""
-        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password" "$PARAMARGS" -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
+        TRIGGERJOBJSON=$(curl --retry=3 --retry-all-errors --retry-connrefused --retry-delay=10 -I -s -X POST -u "$userName:$password" "$PARAMARGS" -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
         
         if [[ $verbose == true ]]; then
           echo "Results of Triggering The Job:"

--- a/action.yml
+++ b/action.yml
@@ -67,9 +67,9 @@ runs:
         #This will return a 201 if the job is created, so we need to test for this
 
         #Generate Crumb value
-        CRUMB=`curl --retry=3 --retry-all-errors --retry-connrefused --retry-delay=10 -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
+        CRUMB=`curl --retry 3 --retry-all-errors --retry-connrefused --retry-delay 10 -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
         echo "curl -I -s -X POST -u \"$userName:$password\" -H \"$CRUMB\" \"$urlOfJenkinsServer\"/job/\"$jenkinsJobName/$BUILDCMD\""
-        TRIGGERJOBJSON=$(curl --retry=3 --retry-all-errors --retry-connrefused --retry-delay=10 -I -s -X POST -u "$userName:$password" "$PARAMARGS" -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
+        TRIGGERJOBJSON=$(curl --retry 3 --retry-all-errors --retry-connrefused --retry-delay 10 -I -s -X POST -u "$userName:$password" "$PARAMARGS" -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
         
         if [[ $verbose == true ]]; then
           echo "Results of Triggering The Job:"

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,13 @@ inputs:
   parameters:
     description: 'build parameters in the format: KEY1=VALUE KEY2=VALUE'
     required: false
+outputs:
+  status: 
+    description: Jenkins Job Status
+    value: ${{ steps.trigger-jenkins-job-using-api.outputs.status }}
+  url: 
+    description: Jenkins Job URL
+    value: ${{ steps.trigger-jenkins-job-using-api.outputs.url }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   parameters:
     description: 'build parameters in the format: KEY1=VALUE KEY2=VALUE'
     required: false
-  
+
 runs:
   using: "composite"
   steps:
@@ -131,6 +131,7 @@ runs:
           echo "Job URL retrieved"
           echo "--------------------------------------"
           BUILDURL=${BASH_REMATCH[3]};
+          echo "url=${BUILDURL}" >> $GITHUB_OUTPUT
           if [[ "${BASH_REMATCH[1]}" == "true" ]]; then
             echo "Build Blocked. Exiting script with error"
             echo "--------------------------------------"
@@ -213,6 +214,7 @@ runs:
 
         #Once I reach here, building is false, so the job isn't running any longer
         #Therefor, we can check the result
+        echo "status=$RESULT" >> $GITHUB_OUTPUT
         case $RESULT in
             SUCCESS)
                 echo "Build completed successfully"

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
         BUILDCMD="build"
         if [[ -n $parameters ]]; then
           BUILDCMD="buildWithParameters?${paramQueryString}"
+        fi
 
         startTime=$(date)
         startTimeSeconds=$(date -d "$startTime" +%s) 

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,8 @@ inputs:
     description: 'true/false - turns on verbose logging'
     required: false
     default: false
-  paramQueryString:
-    description: 'a query string specifying build parameters'
+  parameters:
+    description: 'build parameters in the format: KEY1=VALUE KEY2=VALUE'
     required: false
   
 runs:
@@ -45,8 +45,12 @@ runs:
         paramQueryString="${{ inputs.paramQueryString }}"
 
         BUILDCMD="build"
+        PARAMARGS=""
         if [[ -n $parameters ]]; then
-          BUILDCMD="buildWithParameters?${paramQueryString}"
+          BUILDCMD="buildWithParameters"
+          for $param in $parameters; do
+            echo "-F $param" >> $PARAMARGS
+          done
         fi
 
         startTime=$(date)
@@ -59,7 +63,7 @@ runs:
 
         #Generate Crumb value
         CRUMB=`curl -s -u "$userName:$password" $urlOfJenkinsServer'/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'`
-        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password"  -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
+        TRIGGERJOBJSON=$(curl -I -s -X POST -u "$userName:$password" $PARAMARGS -H "$CRUMB" "$urlOfJenkinsServer"/job/"$jenkinsJobName/$BUILDCMD")
         
         if [[ $verbose == true ]]; then
           echo "Results of Triggering The Job:"


### PR DESCRIPTION
Adds an additional `parameters` argument which will set the trigger url to /buildWithParameters and append the appropriate query string.

Apologies for the ridiculous commit messages. Once approved, I will squash and use the above as the commit message.